### PR TITLE
Fixing title display bug

### DIFF
--- a/recipes/pecan-salmon.html
+++ b/recipes/pecan-salmon.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Pecan Salmon</title>t</title>
+    <title>Pecan Salmon</title>
 </head>
 
 <body>


### PR DESCRIPTION
Fixed bug where title displayed after a "T" on the salmon recipe page.